### PR TITLE
Improve handling of environments

### DIFF
--- a/R/slurm_apply.R
+++ b/R/slurm_apply.R
@@ -104,7 +104,9 @@ slurm_apply <- function(f, params, jobname = NA, nodes = 2, cpus_per_node = 2,
     
     saveRDS(params, file = file.path(tmpdir, "params.RDS"))
     if (!is.null(add_objects)) {
-        save(list = add_objects, file = file.path(tmpdir, "add_objects.RData"))
+        save(list = add_objects,
+             file = file.path(tmpdir, "add_objects.RData"),
+             envir = environment(f))
     }    
     
     # Get chunk size (nb. of param. sets by node)

--- a/R/slurm_apply.R
+++ b/R/slurm_apply.R
@@ -103,6 +103,7 @@ slurm_apply <- function(f, params, jobname = NA, nodes = 2, cpus_per_node = 2,
     dir.create(tmpdir, showWarnings = FALSE)
     
     saveRDS(params, file = file.path(tmpdir, "params.RDS"))
+    saveRDS(f, file = file.path(tmpdir, "f.RDS"))
     if (!is.null(add_objects)) {
         save(list = add_objects,
              file = file.path(tmpdir, "add_objects.RData"),
@@ -125,7 +126,6 @@ slurm_apply <- function(f, params, jobname = NA, nodes = 2, cpus_per_node = 2,
     script_r <- whisker::whisker.render(template_r,
                     list(pkg_list = paste(pkgs, collapse = "','"),
                          add_obj = !is.null(add_objects), 
-                         func = func_to_str(f),
                          nchunk = nchunk, 
                          cpus_per_node = cpus_per_node))
     writeLines(script_r, file.path(tmpdir, "slurm_run.R"))

--- a/R/slurm_call.R
+++ b/R/slurm_call.R
@@ -78,7 +78,9 @@ slurm_call <- function(f, params, jobname = NA, add_objects = NULL,
     
     saveRDS(params, file = file.path(tmpdir, "params.RDS"))
     if (!is.null(add_objects)) {
-        save(list = add_objects, file = file.path(tmpdir, "add_objects.RData"))
+        save(list = add_objects,
+             file = file.path(tmpdir, "add_objects.RData"),
+             envir = environment(f))
     }    
     
     # Create a R script to run function on cluster

--- a/R/slurm_call.R
+++ b/R/slurm_call.R
@@ -77,6 +77,7 @@ slurm_call <- function(f, params, jobname = NA, add_objects = NULL,
     dir.create(tmpdir, showWarnings = FALSE)
     
     saveRDS(params, file = file.path(tmpdir, "params.RDS"))
+    saveRDS(f, file = file.path(tmpdir, "f.RDS"))
     if (!is.null(add_objects)) {
         save(list = add_objects,
              file = file.path(tmpdir, "add_objects.RData"),
@@ -88,8 +89,7 @@ slurm_call <- function(f, params, jobname = NA, add_objects = NULL,
                                         package = "rslurm"))
     script_r <- whisker::whisker.render(template_r,
                     list(pkg_list = paste(pkgs, collapse = "','"),
-                         add_obj = !is.null(add_objects), 
-                         func = func_to_str(f)))
+                         add_obj = !is.null(add_objects)))
     writeLines(script_r, file.path(tmpdir, "slurm_run.R"))
     
     # Create submission bash script

--- a/R/slurm_utils.R
+++ b/R/slurm_utils.R
@@ -1,11 +1,5 @@
 # Utility functions for rslurm package (not exported)
 
-# Convert a function to string
-func_to_str <- function(f) {
-    fstr <- paste(capture.output(f), collapse = "\n")
-    gsub("<environment: [A-Za-z0-9]+>", "", fstr)
-}
-
 
 # Make jobname by cleaning user-provided name or (if NA) generate one
 # from base::tempfile

--- a/inst/templates/slurm_run_R.txt
+++ b/inst/templates/slurm_run_R.txt
@@ -4,8 +4,7 @@
 load('add_objects.RData')
 {{/add_obj}}
 
-.rslurm_func <- {{{func}}}
-
+.rslurm_func <- readRDS('f.RDS')
 .rslurm_params <- readRDS('params.RDS')
 .rslurm_id <- as.numeric(Sys.getenv('SLURM_ARRAY_TASK_ID'))
 .rslurm_istart <- .rslurm_id * {{{nchunk}}} + 1

--- a/inst/templates/slurm_run_single_R.txt
+++ b/inst/templates/slurm_run_single_R.txt
@@ -4,8 +4,7 @@
 load('add_objects.RData')
 {{/add_obj}}
 
-.rslurm_func <- {{{func}}}
-
+.rslurm_func <- readRDS('f.RDS')
 .rslurm_params <- readRDS('params.RDS')
 .rslurm_result <- do.call(.rslurm_func, .rslurm_params)
                

--- a/tests/testthat/test_slurm_apply.R
+++ b/tests/testthat/test_slurm_apply.R
@@ -65,8 +65,22 @@ test_that("slurm_apply works with single parameter and single row", {
     expect_equal(pars$par_m[1], res$s_m, tolerance = 0.01)  
 })
 
+# Test slurm_apply with add_objects
+
+msg <- capture.output(
+    sjob5 <- slurm_apply(function(i) ftest(pars[i, 1], pars[i, 2]),
+                         data.frame(i = 1:nrow(pars)),
+                         add_objects = c('ftest', 'pars'), jobname = "test5",
+                         nodes = 2, cpus_per_node = 1, submit = FALSE)
+)
+sjob5 <- local_slurm_array(sjob5)
+res <- get_slurm_out(sjob5, "table", wait = FALSE)
+test_that("slurm_apply correctly handles add_objects", {
+    expect_equal(pars, res, tolerance = 0.01, check.attributes = FALSE)
+})
+
 
 # Cleanup all temporary files at the end
 # Pause to make sure folders are free to be deleted
 Sys.sleep(1)
-lapply(list(sjob1, sjob2, sjob3, sjob4), cleanup_files, wait = FALSE)
+lapply(list(sjob1, sjob2, sjob3, sjob4, sjob5), cleanup_files, wait = FALSE)

--- a/tests/testthat/test_slurm_call.R
+++ b/tests/testthat/test_slurm_call.R
@@ -5,10 +5,12 @@ Sys.setenv(R_TESTS = "")
 
 # Test slurm_call locally
 
-msg <- capture.output(
-    sjob <- slurm_call(function(x, y) x * 2 + y, list(x = 5, y = 6), 
+msg <- capture.output({
+    z <- 0
+    sjob <- slurm_call(function(x, y) x * 2 + y + z, list(x = 5, y = 6),
+                       add_objects = c('z'),
                        jobname = "test^\\* call", submit = FALSE)
-)
+})
 
 test_that("slurm_job name is correctly edited", {
     expect_equal(sjob$jobname, "test_call")


### PR DESCRIPTION
Work to improve the handling of environments for the `add_objects` parameter and the function to be evaluated was stimulated by #11 and a related [stack question](https://stackoverflow.com/q/44681304/687112). Thanks, @rcorty!

The first commit addresses sending additional data to cluster nodes, recognizing that the natural place to begin searching for objects named in the `add_objects` character vector is the enclosing environment of the function being SLURM'd. The commit also adds a relevant testthat test.

The second commit is more experimental. Rather than stringifying the function to be evaluated on the cluster, the serialized function is saved and loaded. Could @pmarchand1 chime in on the original reason to template the function and gsub away any attributes, enclosing environment, etc.?