### PR TITLE
Custom templates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Authors@R: c(person('Philippe', 'Marchand', role = 'aut'),
              person('Mike', 'Smorul', role = 'ctb'),
              person('Ian', 'Carroll',
                     email = 'icarroll@sesync.org', role = c('ctb', 'cre')),
-                     person('Jonathan', 'Greenberg', role = 'ctb'),)
+             person('Jonathan', 'Greenberg', role = 'ctb'))
 Depends:
     R (>= 3.2.0)
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,14 +7,15 @@ Description: Functions that simplify submitting R scripts to a Slurm
 Acknowledgements: Development of this R package was supported by the National
     Socio-Environmental Synthesis Center (SESYNC) under funding received from
     the National Science Foundation DBI-1052875.
-Version: 0.4.0.9000
+Version: 0.4.0.9001
 License: GPL-3
 URL: https://github.com/SESYNC-ci/rslurm
 BugReports: https://github.com/SESYNC-ci/rslurm/issues
 Authors@R: c(person('Philippe', 'Marchand', role = 'aut'), 
              person('Mike', 'Smorul', role = 'ctb'),
              person('Ian', 'Carroll',
-                    email = 'icarroll@sesync.org', role = c('ctb', 'cre')))
+                    email = 'icarroll@sesync.org', role = c('ctb', 'cre')),
+                     person('Jonathan', 'Greenberg', role = 'ctb'),)
 Depends:
     R (>= 3.2.0)
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,11 +16,7 @@ Author: c(person('Philippe', 'Marchand', role = 'aut'),
              person('Ian', 'Carroll',
                     email = 'icarroll@sesync.org', role = c('ctb', 'cre')),
              person('Jonathan', 'Greenberg', role = 'ctb'))
-Maintainer: c(person('Philippe', 'Marchand', role = 'aut'), 
-             person('Mike', 'Smorul', role = 'ctb'),
-             person('Ian', 'Carroll',
-                    email = 'icarroll@sesync.org', role = c('ctb', 'cre')),
-             person('Jonathan', 'Greenberg', role = 'ctb'))
+Maintainer: Jonathan Greenberg <jgreenberg@unr.edu>
 Depends:
     R (>= 3.2.0)
 Imports:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,12 @@ Version: 0.4.0.9001
 License: GPL-3
 URL: https://github.com/SESYNC-ci/rslurm
 BugReports: https://github.com/SESYNC-ci/rslurm/issues
-Authors@R: c(person('Philippe', 'Marchand', role = 'aut'), 
+Author: c(person('Philippe', 'Marchand', role = 'aut'), 
+             person('Mike', 'Smorul', role = 'ctb'),
+             person('Ian', 'Carroll',
+                    email = 'icarroll@sesync.org', role = c('ctb', 'cre')),
+             person('Jonathan', 'Greenberg', role = 'ctb'))
+Maintainer: c(person('Philippe', 'Marchand', role = 'aut'), 
              person('Mike', 'Smorul', role = 'ctb'),
              person('Ian', 'Carroll',
                     email = 'icarroll@sesync.org', role = c('ctb', 'cre')),

--- a/R/get_slurm_out.R
+++ b/R/get_slurm_out.R
@@ -25,7 +25,13 @@
 #' @seealso \code{\link{slurm_apply}}, \code{\link{slurm_call}}
 #' @export
 get_slurm_out <- function(slr_job, outtype = "raw", wait = TRUE) {
-    
+ 
+	if(class(slr_job)=="character")
+	{
+		slr_job_file <- file.path(slr_job,"slurm_job.Rdata")
+		if(file.exists(slr_job_file)) load(slr_job_file) else stop("slr_job must be a path to the slurm job directory...")
+	}
+	
     # Check arguments
     if (!(class(slr_job) == "slurm_job")) {
         stop("slr_job must be a slurm_job")

--- a/R/slurm_apply.R
+++ b/R/slurm_apply.R
@@ -162,6 +162,10 @@ slurm_apply <- function(f, params, jobname = NA, nodes = 2, cpus_per_node = 2,
 		cat(paste("Submission scripts output in directory", tmpdir))
 	}
 	
+	# Save slurm_job object:
+	slr_job <- slurm_job(jobname, nodes)	
+	save(slr_job,file=file.path(tmpdir,"slurm_job.Rdata"))
+	
 	# Return 'slurm_job' object
-	slurm_job(jobname, nodes)
+	return(slr_job)
 }

--- a/R/slurm_call.R
+++ b/R/slurm_call.R
@@ -104,7 +104,7 @@ slurm_call <- function(f, params, jobname = NA, add_objects = NULL,
     writeLines(script_r, file.path(tmpdir, "slurm_run.R"))
     
     # Create submission bash script
-    template_sh <- readLines(slurm_run_single_fname)
+    template_sh <- readLines(submit_single_sh_fname)
     slurm_options <- format_option_list(slurm_options)
 #    rscript_path <- file.path(R.home("bin"), "Rscript")
     script_sh <- whisker::whisker.render(template_sh, 

--- a/R/slurm_call.R
+++ b/R/slurm_call.R
@@ -52,6 +52,9 @@
 #'   Details below for more information.
 #' @param submit Whether or not to submit the job to the cluster with 
 #'   \code{sbatch}; see Details below for more information.
+#' @param rscript_path Path to Rscript -- defaults to the bin directory of the current R
+#' @param submit_single_sh_fname Path to the submit_single_sh.txt template.  Defaults to the templates directory.  
+
 #' @return A \code{slurm_job} object containing the \code{jobname} and the number
 #'   of \code{nodes} effectively used.
 #' @seealso \code{\link{slurm_apply}} to parallelize a function over a parameter
@@ -62,7 +65,10 @@
 #' @export
 slurm_call <- function(f, params, jobname = NA, add_objects = NULL, 
                        pkgs = rev(.packages()), libPaths = NULL,
-                       slurm_options = list(), submit = TRUE) {
+                       slurm_options = list(), submit = TRUE,
+					   rscript_path = file.path(R.home("bin"), "Rscript"),
+					   submit_single_sh_fname=system.file("templates/submit_single_sh.txt", 
+							   package = "rslurm")) {
     # Check inputs
     if (!is.function(f)) {
         stop("first argument to slurm_call should be a function")
@@ -98,10 +104,9 @@ slurm_call <- function(f, params, jobname = NA, add_objects = NULL,
     writeLines(script_r, file.path(tmpdir, "slurm_run.R"))
     
     # Create submission bash script
-    template_sh <- readLines(system.file("templates/submit_single_sh.txt", 
-                                         package = "rslurm"))
+    template_sh <- readLines(slurm_run_single_fname)
     slurm_options <- format_option_list(slurm_options)
-    rscript_path <- file.path(R.home("bin"), "Rscript")
+#    rscript_path <- file.path(R.home("bin"), "Rscript")
     script_sh <- whisker::whisker.render(template_sh, 
                                          list(jobname = jobname,
                                               flags = slurm_options$flags, 

--- a/R/slurm_call.R
+++ b/R/slurm_call.R
@@ -125,6 +125,10 @@ slurm_call <- function(f, params, jobname = NA, add_objects = NULL,
         cat(paste("Submission scripts output in directory", tmpdir))
     }
 
-    # Return 'slurm_job' object
-    slurm_job(jobname, 1)
+	# Save slurm_job object:
+	slr_job <- slurm_job(jobname, 1)	
+	save(slr_job,file=file.path(tmpdir,"slurm_job.Rdata"))
+	
+	# Return 'slurm_job' object
+	return(slr_job)
 }

--- a/man/slurm_apply.Rd
+++ b/man/slurm_apply.Rd
@@ -6,7 +6,10 @@
 \usage{
 slurm_apply(f, params, jobname = NA, nodes = 2, cpus_per_node = 2,
   add_objects = NULL, pkgs = rev(.packages()), libPaths = NULL,
-  slurm_options = list(), submit = TRUE)
+  slurm_options = list(), submit = TRUE,
+  rscript_path = file.path(R.home("bin"), "Rscript"),
+  submit_sh_fname = system.file("templates/submit_sh.txt", package =
+  "rslurm"))
 }
 \arguments{
 \item{f}{A function that accepts one or many single values as parameters and
@@ -45,6 +48,10 @@ Details below for more information.}
 
 \item{submit}{Whether or not to submit the job to the cluster with
 \code{sbatch}; see Details below for more information.}
+
+\item{rscript_path}{Path to Rscript -- defaults to the bin directory of the current R}
+
+\item{submit_sh_fname}{Path to the submit_sh.txt template.  Defaults to the templates directory.}
 }
 \value{
 A \code{slurm_job} object containing the \code{jobname} and the

--- a/man/slurm_call.Rd
+++ b/man/slurm_call.Rd
@@ -6,7 +6,9 @@
 \usage{
 slurm_call(f, params, jobname = NA, add_objects = NULL,
   pkgs = rev(.packages()), libPaths = NULL, slurm_options = list(),
-  submit = TRUE)
+  submit = TRUE, rscript_path = file.path(R.home("bin"), "Rscript"),
+  submit_single_sh_fname = system.file("templates/submit_single_sh.txt",
+  package = "rslurm"))
 }
 \arguments{
 \item{f}{Any R function.}
@@ -34,6 +36,10 @@ Details below for more information.}
 
 \item{submit}{Whether or not to submit the job to the cluster with 
 \code{sbatch}; see Details below for more information.}
+
+\item{rscript_path}{Path to Rscript -- defaults to the bin directory of the current R}
+
+\item{submit_single_sh_fname}{Path to the submit_single_sh.txt template.  Defaults to the templates directory.}
 }
 \value{
 A \code{slurm_job} object containing the \code{jobname} and the number


### PR DESCRIPTION
Ian, thanks for the insight on merging -- looks like there may be a few non-whitespace changes that are just tabbing (sorry about that), but here are my responses to your questions:

1) Can modifying the Rscript path be achieved by modifying the template, so that only one new parameter (path to template) need be introduced?
-> My thought was at least for our use case, we just needed to change the Rscript executable location, which is an easier parameter to set than having to modify the template.  I set the default parameter to be what you had in your code, so there should be functionally no difference in execution between the original rslurm and my fork.  You already have an easy way to se the Rscript parameter, so I figured why not use it?
2) If a single line of code or two (i.e. save(sjob, 'sjob.Rdata')) can be equally effective inside and outside the package, I prefer to keep it outside. The user can already save slurm job objects as needed.
-> My thought with this was I was a bit confused how to "properly" restart the job.  This is an additional step that I can see users forgetting to do, running a big job, exiting the "master" R job, and then not knowing how to piece everything back together.  I figured a small file placed in the job folder wouldn't be a big deal and would let a user easily restart/merge the jobs by simply pointing at the job folder (where all the outputs are stored).  
3) The Authors variable in the DESCRIPTION does not include all contributors, much like manuscript authorship. By issuing a PR, your contribution will be shown in the repository contributors.
-> Thanks!  I tweaked the DESCRIPTION to match my contribution (so I could keep them straight as well) but I didn't know if that was something you do or the contributors manually add-in.