### PR TITLE
 Modify within-cluster parallel backend for dynamic load balancing

### DIFF
--- a/inst/templates/slurm_run_R.txt
+++ b/inst/templates/slurm_run_R.txt
@@ -12,10 +12,12 @@ load('add_objects.RData')
 .rslurm_id <- as.numeric(Sys.getenv('SLURM_ARRAY_TASK_ID'))
 .rslurm_istart <- .rslurm_id * {{{nchunk}}} + 1
 .rslurm_iend <- min((.rslurm_id + 1) * {{{nchunk}}}, nrow(.rslurm_params))
-.rslurm_result <- do.call(parallel::mcmapply, c(
-    FUN = .rslurm_func,
-    .rslurm_params[.rslurm_istart:.rslurm_iend, , drop = FALSE],
-    mc.cores = {{{cpus_per_node}}},
-    SIMPLIFY = FALSE))
-
+.cl <- makeCluster({{{cpus_per_node}}}, outfile = '')
+parallel::setDefaultCluster(.cl)
+.rslurm_result <- do.call(parallel::clusterMap,
+                          c(fun = .rslurm_func,
+                            .scheduling = 'dynamic',
+                            .rslurm_params[.rslurm_istart:.rslurm_iend, ,
+                                           drop = FALSE]))
+stopCluster(.cl)
 saveRDS(.rslurm_result, file = paste0('results_', .rslurm_id, '.RDS'))

--- a/inst/templates/slurm_run_R.txt
+++ b/inst/templates/slurm_run_R.txt
@@ -12,12 +12,12 @@ load('add_objects.RData')
 .rslurm_id <- as.numeric(Sys.getenv('SLURM_ARRAY_TASK_ID'))
 .rslurm_istart <- .rslurm_id * {{{nchunk}}} + 1
 .rslurm_iend <- min((.rslurm_id + 1) * {{{nchunk}}}, nrow(.rslurm_params))
-.cl <- makeCluster({{{cpus_per_node}}}, outfile = '')
+.cl <- parallel::makeCluster({{{cpus_per_node}}}, outfile = '')
 parallel::setDefaultCluster(.cl)
 .rslurm_result <- do.call(parallel::clusterMap,
                           c(fun = .rslurm_func,
                             .scheduling = 'dynamic',
                             .rslurm_params[.rslurm_istart:.rslurm_iend, ,
                                            drop = FALSE]))
-stopCluster(.cl)
+parallel::stopCluster(.cl)
 saveRDS(.rslurm_result, file = paste0('results_', .rslurm_id, '.RDS'))


### PR DESCRIPTION
The base `parallel::mcmapply` implementation works well but `parallel::clusterMap` allows for dynamic load balancing across threads.