### PR TITLE
Set cpus-per-tasks in sbatch script

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Depends:
     R (>= 3.2.0)
 Imports:
     whisker (>= 0.3)
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1
 Suggests:
     parallel,
     testthat,

--- a/R/slurm_apply.R
+++ b/R/slurm_apply.R
@@ -141,6 +141,7 @@ slurm_apply <- function(f, params, jobname = NA, nodes = 2, cpus_per_node = 2,
     rscript_path <- file.path(R.home("bin"), "Rscript")
     script_sh <- whisker::whisker.render(template_sh,
                     list(max_node = nodes - 1,
+                         cpus_per_node = cpus_per_node,
                          jobname = jobname,
                          flags = slurm_options$flags,
                          options = slurm_options$options,

--- a/R/slurm_apply.R
+++ b/R/slurm_apply.R
@@ -49,9 +49,9 @@
 #'   over. \code{slurm_apply} automatically divides \code{params} in chunks of
 #'   approximately equal size to send to each node. Less nodes are allocated if
 #'   the parameter set is too small to use all CPUs on the requested nodes.
-#' @param cpus_per_node The number of CPUs requested per node, i.e. how many
-#'   processes to run in parallel per node; this is mapped to the
-#'   "cpus-per-task" Slurm parameter."
+#' @param cpus_per_node The number of CPUs requested per node, i.e., how many
+#'   processes to run in parallel per node. This argument is mapped to the
+#'   Slurm parameter \code{cpus-per-task}.
 #' @param add_objects A character vector containing the name of R objects to be
 #'   saved in a .RData file and loaded on each cluster node prior to calling
 #'   \code{f}.

--- a/R/slurm_apply.R
+++ b/R/slurm_apply.R
@@ -17,9 +17,9 @@
 #' \code{slurm_options = list(time = "1:00:00", share = TRUE)}.
 #' See \url{http://slurm.schedmd.com/sbatch.html} for details on possible options.
 #' Note that full names must be used (e.g. "time" rather than "t") and that flags
-#' (such as "share") must be specified as TRUE. The "array", "job-name", "nodes"
-#' and "output" options are already determined by \code{slurm_apply} and should
-#' not be manually set.
+#' (such as "share") must be specified as TRUE. The "array", "job-name", "nodes", 
+#' "cpus-per-task" and "output" options are already determined by 
+#' \code{slurm_apply} and should not be manually set.
 #'
 #' When processing the computation job, the Slurm cluster will output two types
 #' of files in the temporary folder: those containing the return values of the
@@ -49,8 +49,9 @@
 #'   over. \code{slurm_apply} automatically divides \code{params} in chunks of
 #'   approximately equal size to send to each node. Less nodes are allocated if
 #'   the parameter set is too small to use all CPUs on the requested nodes.
-#' @param cpus_per_node The number of CPUs per node on the cluster; determines how
-#'   many processes are run in parallel per node.
+#' @param cpus_per_node The number of CPUs requested per node, i.e. how many
+#'   processes to run in parallel per node; this is mapped to the
+#'   "cpus-per-task" Slurm parameter."
 #' @param add_objects A character vector containing the name of R objects to be
 #'   saved in a .RData file and loaded on each cluster node prior to calling
 #'   \code{f}.

--- a/inst/templates/submit_sh.txt
+++ b/inst/templates/submit_sh.txt
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 #SBATCH --array=0-{{{max_node}}}
+#SBATCH --cpus-per-task={{{cpus_per_node}}}
 #SBATCH --job-name={{{jobname}}}
 #SBATCH --output=slurm_%a.out
 {{#flags}}

--- a/man/rslurm-package.Rd
+++ b/man/rslurm-package.Rd
@@ -12,13 +12,13 @@ using the \code{\link{slurm_call}} or \code{\link{slurm_apply}} functions.
 
   
   This package includes two core functions used to send computations to a 
-  Slurm cluster. While \code{\link{slurm_call}} executes a function using a 
-  single set of parameters (passed as a list), \code{\link{slurm_apply}} 
-  evaluates the function in parallel for multiple sets of parameters grouped 
-  in a data frame. \code{slurm_apply} automatically splits the parameter sets
-  into equal-size chunks, each chunk to be processed by a separate cluster 
+  Slurm cluster: 1) \code{\link{slurm_call}} executes a function using a 
+  single set of parameters (passed as a list), and 2) \code{\link{slurm_apply}} 
+  evaluates a function in parallel for each row of parameters in a given 
+  data frame. The second, \code{slurm_apply}, automatically splits the parameter
+  rows into equal-size chunks, each chunk to be processed by a separate cluster 
   node. It uses functions from the \code{\link[parallel]{parallel}} package 
-  to parallelize computations within each node.
+  to parallelize computations across processors on a given node.
   
   The output of \code{slurm_apply} or \code{slurm_call} is a \code{slurm_job}
   object that serves as an input to the other functions in the package: 
@@ -55,6 +55,18 @@ using the \code{\link{slurm_call}} or \code{\link{slurm_apply}} functions.
   the function passed to \code{slurm_apply} produces a vector output, you may
   use \code{outtype = "table"} to collect the output in a single data frame, 
   with one row by function call.
+}
+
+\section{Slurm Configuration}{
+
+  
+  Advanced options for the Slurm workload manager may accompany job submission
+  by both \code{\link{slurm_call}} and \code{\link{slurm_apply}} through the 
+  optional \code{slurm_options} argument. For example, passing
+  \code{list(time = '1:30')} for this options limits the job to 1 hour and 30
+  minutes. Some advanced configuration must be set through environment 
+  variables. On a multi-cluster head node, for example, the \code{SLURM_CLUSTERS}
+  environment variable must be set to direct jobs to a non-default cluster.
 }
 
 \examples{

--- a/man/slurm_apply.Rd
+++ b/man/slurm_apply.Rd
@@ -24,9 +24,9 @@ over. \code{slurm_apply} automatically divides \code{params} in chunks of
 approximately equal size to send to each node. Less nodes are allocated if
 the parameter set is too small to use all CPUs on the requested nodes.}
 
-\item{cpus_per_node}{The number of CPUs requested per node, i.e. how many
-processes to run in parallel per node; this is mapped to the
-"cpus-per-task" Slurm parameter."}
+\item{cpus_per_node}{The number of CPUs requested per node, i.e., how many
+processes to run in parallel per node. This argument is mapped to the
+Slurm parameter \code{cpus-per-task}.}
 
 \item{add_objects}{A character vector containing the name of R objects to be
 saved in a .RData file and loaded on each cluster node prior to calling

--- a/man/slurm_apply.Rd
+++ b/man/slurm_apply.Rd
@@ -24,8 +24,9 @@ over. \code{slurm_apply} automatically divides \code{params} in chunks of
 approximately equal size to send to each node. Less nodes are allocated if
 the parameter set is too small to use all CPUs on the requested nodes.}
 
-\item{cpus_per_node}{The number of CPUs per node on the cluster; determines how
-many processes are run in parallel per node.}
+\item{cpus_per_node}{The number of CPUs requested per node, i.e. how many
+processes to run in parallel per node; this is mapped to the
+"cpus-per-task" Slurm parameter."}
 
 \item{add_objects}{A character vector containing the name of R objects to be
 saved in a .RData file and loaded on each cluster node prior to calling
@@ -69,9 +70,9 @@ Use \code{slurm_options} to set any option recognized by \code{sbatch}, e.g.
 \code{slurm_options = list(time = "1:00:00", share = TRUE)}.
 See \url{http://slurm.schedmd.com/sbatch.html} for details on possible options.
 Note that full names must be used (e.g. "time" rather than "t") and that flags
-(such as "share") must be specified as TRUE. The "array", "job-name", "nodes"
-and "output" options are already determined by \code{slurm_apply} and should
-not be manually set.
+(such as "share") must be specified as TRUE. The "array", "job-name", "nodes", 
+"cpus-per-task" and "output" options are already determined by 
+\code{slurm_apply} and should not be manually set.
 
 When processing the computation job, the Slurm cluster will output two types
 of files in the temporary folder: those containing the return values of the


### PR DESCRIPTION
Fixes #33 

I did not rename `cpus_per_node`. While there is a discrepancy with the slurm option name, I like the easier to understand option pair `nodes` and `cpus_per_node`. In addition, it's backwards compatible.
If you like it, I could add a comment to the documentation about `cpus_per_node` and `#SBATCH --cpus-per-task`.