### PR TITLE
changed wait_for_job to not use the --wait sbatch flag

### DIFF
--- a/R/slurm_utils.R
+++ b/R/slurm_utils.R
@@ -54,12 +54,8 @@ wait_for_job <- function(slr_job) {
         flagfile <- tempfile(pattern="flag", tmpdir=tmp)
         block_cmd <- sprintf('sbatch -o/dev/null -t00:01:00 -dsingleton -J%s --wrap="touch %s"', slr_job$jobname, flagfile)
         system(block_cmd, intern=TRUE)
-        while (TRUE) {
-            if (file.exists(flagfile)) {
-                break
-            } else {
-                Sys.sleep(30)
-            }
+        while (!file.exists(flagfile)) {
+            Sys.sleep(10)
         }
         file.remove(flagfile)
     }


### PR DESCRIPTION
We've noticed a lot of RPC requests to our slurm controller from rslurm and believe it to be the result of using the `--wait` sbatch flag which actively queries the slurm controller. I'm proposing to change `wait_for_job` such that instead of using `--wait` it submits a dependent job without `--wait` which touches a flag file and then actively monitors for the existence of the flag file.