### PR TITLE
README touchup

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -1,5 +1,11 @@
 ---
-output: github_document
+output:
+  github_document:
+    html_preview: false
+    md_extensions: -smart
+    pandoc_args:
+      - "--wrap"
+      - "preserve"
 ---
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
@@ -19,7 +25,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![rstudio mirror downloads](https://cranlogs.r-pkg.org/badges/rslurm)](https://CRAN.R-project.org/package=rslurm)
-[![R build status]https://github.com/earthlab/rslurm/workflows/R-CMD-check/badge.svg)](https://github.com/earthlab/rslurm/actions)
+[![R build status](https://github.com/earthlab/rslurm/workflows/R-CMD-check/badge.svg)](https://github.com/earthlab/rslurm/actions)
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![CRAN status](https://www.r-pkg.org/badges/version/rslurm)](https://CRAN.R-project.org/package=rslurm)
 [![DOI](https://zenodo.org/badge/37485241.svg)](https://zenodo.org/badge/latestdoi/37485241)

--- a/README.md
+++ b/README.md
@@ -1,18 +1,14 @@
----
-output: github_document
----
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-
-
-<img src="man/figures/logo_slurm.png" align="right" width=150px>  
+<img src="man/figures/logo_slurm.png" align="right" width=150px>
 
 # rslurm: submit R code to a Slurm cluster
 
 <!-- badges: start -->
+
 [![rstudio mirror downloads](https://cranlogs.r-pkg.org/badges/rslurm)](https://CRAN.R-project.org/package=rslurm)
-[![R build status]https://github.com/earthlab/rslurm/workflows/R-CMD-check/badge.svg)](https://github.com/earthlab/rslurm/actions)
+[![R build status](https://github.com/earthlab/rslurm/workflows/R-CMD-check/badge.svg)](https://github.com/earthlab/rslurm/actions)
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![CRAN status](https://www.r-pkg.org/badges/version/rslurm)](https://CRAN.R-project.org/package=rslurm)
 [![DOI](https://zenodo.org/badge/37485241.svg)](https://zenodo.org/badge/latestdoi/37485241)
@@ -32,15 +28,13 @@ rslurm and is responsible for all future maintenance.
 
 You can install the released version of [rslurm](https://cran.r-project.org/package=rslurm) from [CRAN](https://CRAN.R-project.org) with:
 
-
-```r
+``` r
 install.packages("rslurm")
 ```
 
 And the development version from [GitHub](https://github.com/earthlab/rslurm) with:
 
-
-```r
+``` r
 # install.packages("devtools")
 devtools::install_github("earthlab/rslurm")
 ```
@@ -60,8 +54,7 @@ To illustrate a typical rslurm workflow, we use a simple function that takes
 a mean and standard deviation as parameters, generates a million normal deviates
 and returns the sample mean and standard deviation.
 
-
-```r
+``` r
 test_func <- function(par_mu, par_sd) {
     samp <- rnorm(10^6, par_mu, par_sd)
     c(s_mu = mean(samp), s_sd = sd(samp))
@@ -71,8 +64,7 @@ test_func <- function(par_mu, par_sd) {
 We then create a parameter data frame where each row is a parameter set and each
 column matches an argument of the function.
 
-
-```r
+``` r
 pars <- data.frame(par_mu = 1:10,
                    par_sd = seq(0.1, 1, length.out = 10))
 ```
@@ -80,15 +72,14 @@ pars <- data.frame(par_mu = 1:10,
 We can now pass that function and the parameters data frame to `slurm_apply`,
 specifying the number of cluster nodes to use and the number of CPUs per node.
 
-
-```r
+``` r
 library(rslurm)
 sjob <- slurm_apply(test_func, pars, jobname = 'test_apply',
                     nodes = 2, cpus_per_node = 2, submit = FALSE)
 ```
 
-The output of `slurm_apply` is a `slurm_job` object that stores a few pieces of 
+The output of `slurm_apply` is a `slurm_job` object that stores a few pieces of
 information (job name, job ID, and the number of nodes) needed to retrieve the
 job's output.
 
-See [Get started](https://www.earthdatascience.org/rslurm/articles/rslurm.html) for more information.  
+See [Get started](https://www.earthdatascience.org/rslurm/articles/rslurm.html) for more information.


### PR DESCRIPTION
The RStudio "knit" button, which generated the previous `README.md` is closer to `rmarkdown::render` than `knitr::knit`, which appears to have been used to generate the latest `README.md`. Doesn't pick up on the `github_document`.

I added some render options to make the result a little more like just knitting. Some whitespace still changed.

Also, a parenthesis got dropped in a badge image url.